### PR TITLE
Fix M5Core2 library declaration

### DIFF
--- a/co2-sensor/platformio.ini
+++ b/co2-sensor/platformio.ini
@@ -22,7 +22,7 @@ build_flags =
 	-D LWIP_SNMP
 framework = arduino
 lib_deps = 
-	https://github.com/m5stack/M5Core2.git@0.0.6
+	m5stack/M5Core2@0.0.6
 	https://github.com/khoih-prog/ESPAsync_WiFiManager.git#f482bb81425e2cb8b14c0a5283925a3d62c2f8db
 	sparkfun/SparkFun SCD30 Arduino Library@1.0.10
 	arduino-libraries/NTPClient@3.1.0


### PR DESCRIPTION
Compilation of this project fails horribly for newer PlatformIO core versions since `gitrepo@<version>` is not valid syntax, `gitrepo#<tag / hash>` is. However, in this case the library can be simply pulled from [the registry](https://platformio.org/lib/show/11080/M5Core2/installation). 

This emerged as part of the discussion in https://community.platformio.org/t/upload-error-m5stack-core2/24694?u=maxgerhardt.